### PR TITLE
Cc3200sdk1.1.0 compat

### DIFF
--- a/example/keen-cc3200/.cproject
+++ b/example/keen-cc3200/.cproject
@@ -33,6 +33,7 @@
 								<option id="com.ti.ccstudio.buildDefinitions.TMS470_5.1.compilerID.DEFINE.285849662" name="Pre-define NAME (--define, -D)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_5.1.compilerID.DEFINE" valueType="definedSymbols">
 									<listOptionValue builtIn="false" value="ccs"/>
 									<listOptionValue builtIn="false" value="cc3200"/>
+									<listOptionValue builtIn="false" value="CC3200SDK_1_1_0"/>
 								</option>
 								<option id="com.ti.ccstudio.buildDefinitions.TMS470_5.1.compilerID.SILICON_VERSION.1386937434" name="Target processor version (--silicon_version, -mv)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_5.1.compilerID.SILICON_VERSION" value="com.ti.ccstudio.buildDefinitions.TMS470_5.1.compilerID.SILICON_VERSION.7M4" valueType="enumerated"/>
 								<option id="com.ti.ccstudio.buildDefinitions.TMS470_5.1.compilerID.CODE_STATE.1352748661" name="Designate code state, 16-bit (thumb) or 32-bit (--code_state)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_5.1.compilerID.CODE_STATE" value="com.ti.ccstudio.buildDefinitions.TMS470_5.1.compilerID.CODE_STATE.16" valueType="enumerated"/>

--- a/example/keen-cc3200/.project
+++ b/example/keen-cc3200/.project
@@ -48,7 +48,7 @@
 		</variable>
 		<variable>
 			<name>ORIGINAL_PROJECT_ROOT</name>
-			<value>file:/C:/ti/CC3200SDK_1.0.0/cc3200-sdk/example/ssl/ccs</value>
+			<value>file:/C:/ti/CC3200SDK_1.1.0/cc3200-sdk/example/ssl/ccs</value>
 		</variable>
 	</variableList>
 </projectDescription>

--- a/example/keen-cc3200/boilerplate.c
+++ b/example/keen-cc3200/boilerplate.c
@@ -374,6 +374,7 @@ void SimpleLinkGeneralEventHandler(SlDeviceEvent_t *pDevEvent)
 //! \return None
 //!
 //*****************************************************************************
+#ifdef CC3200SDK_1_1_0
 void SimpleLinkSockEventHandler(SlSockEvent_t *pSock)
 {
     if(!pSock)
@@ -395,7 +396,6 @@ void SimpleLinkSockEventHandler(SlSockEvent_t *pSock)
                     UART_PRINT("[SOCK ERROR] - TX FAILED  :  socket %d , "
                                "reason (%d) \n\n",
                                pSock->socketAsyncEvent.SockTxFailData.sd, pSock->socketAsyncEvent.SockTxFailData.status);
-                    break;
             }
             break;
 
@@ -404,6 +404,37 @@ void SimpleLinkSockEventHandler(SlSockEvent_t *pSock)
             //UART_PRINT("[SOCK EVENT] - Unexpected Event [%x0x]\n\n",pSock->Event);
     }
 }
+#else
+void SimpleLinkSockEventHandler(SlSockEvent_t *pSock)
+{
+    if(!pSock)
+    {
+        return;
+    }
+
+    switch( pSock->Event )
+    {
+        case SL_SOCKET_TX_FAILED_EVENT:
+            switch( pSock->EventData.status )
+            {
+                case SL_ECLOSE:
+                    UART_PRINT("[SOCK ERROR] - close socket (%d) operation "
+                               "failed to transmit all queued packets\n\n",
+                               pSock->EventData.sd);
+                    break;
+                default:
+                    UART_PRINT("[SOCK ERROR] - TX FAILED  :  socket %d , "
+                               "reason (%d) \n\n",
+                               pSock->EventData.sd, pSock->EventData.status);
+            }
+            break;
+
+        default:
+            break;
+            //UART_PRINT("[SOCK EVENT] - Unexpected Event [%x0x]\n\n",pSock->Event);
+    }
+}
+#endif
 
 
 //*****************************************************************************

--- a/example/keen-cc3200/boilerplate.c
+++ b/example/keen-cc3200/boilerplate.c
@@ -384,17 +384,18 @@ void SimpleLinkSockEventHandler(SlSockEvent_t *pSock)
     switch( pSock->Event )
     {
         case SL_SOCKET_TX_FAILED_EVENT:
-            switch( pSock->EventData.status )
+            switch( pSock->socketAsyncEvent.SockTxFailData.status)
             {
                 case SL_ECLOSE:
                     UART_PRINT("[SOCK ERROR] - close socket (%d) operation "
                                "failed to transmit all queued packets\n\n",
-                               pSock->EventData.sd);
+                               pSock->socketAsyncEvent.SockTxFailData.sd);
                     break;
                 default:
                     UART_PRINT("[SOCK ERROR] - TX FAILED  :  socket %d , "
                                "reason (%d) \n\n",
-                               pSock->EventData.sd, pSock->EventData.status);
+                               pSock->socketAsyncEvent.SockTxFailData.sd, pSock->socketAsyncEvent.SockTxFailData.status);
+                    break;
             }
             break;
 

--- a/keen-cc3200/.project
+++ b/keen-cc3200/.project
@@ -31,7 +31,7 @@
 		</variable>
 		<variable>
 			<name>ORIGINAL_PROJECT_ROOT</name>
-			<value>file:/C:/ti/CC3200SDK_1.0.0/cc3200-sdk/example/ssl/ccs</value>
+			<value>file:/C:/ti/CC3200SDK_1.1.0/cc3200-sdk/example/ssl/ccs</value>
 		</variable>
 	</variableList>
 </projectDescription>


### PR DESCRIPTION
Will resolve #2. Added predefined symbol `CC3200SDK_1_1_0` so we can support both versions of the SDK.
- Verification
  - Successfully compiled and tested against `CC3200SDK_1.0.0` with service pack `CC31xx_CC32xx_ServicePack_1.0.0.1.2` 
  - Successfully compiled and tested against `CC3200SDK_1.1.0` with service pack `CC31xx_CC32xx_ServicePack_1.0.0.10.0`
